### PR TITLE
Bug Fix for server hang on bad JWT

### DIFF
--- a/api/middleware/authRequired.js
+++ b/api/middleware/authRequired.js
@@ -35,6 +35,10 @@ const authRequired = async (req, res, next) => {
           throw new Error('Unable to process idToken');
         }
         next();
+      })
+      .catch((err) => {
+        console.error(err);
+        next(createError(401), err.message);
       });
   } catch (err) {
     next(createError(401, err.message));


### PR DESCRIPTION
## Description
There is an issue where the server never sends a response to the client when a bad or expired JWT is sent, the result is the server getting hung up and stalling the app. This should take care of that issue!
Type
- [x] This is a bugfix.
- [ ] This is a new feature.
- [ ] This is part of a feature.
## Organization
- [ ] Have you linked this pull request to a Trello card?
- [ ] Have you named the branch in the format of feature/describe_feature_or_change OR bug/describe_bug_this_is_fixing
## Review
- [ ] Is this a work in progress?
- [x]  Is this ready to be reviewed?
-  [ ] Have you added two reviewers to this pull request?